### PR TITLE
Fix intersection between points and intervals

### DIFF
--- a/lib/borel/interval_simple.rb
+++ b/lib/borel/interval_simple.rb
@@ -21,7 +21,9 @@ class Interval::Simple < Interval
 
   # @return [Interval]
   def intersect(other)
-    Interval[[inf, other.inf].max, [sup, other.sup].min]
+    other.map{ |component|
+      Interval[[inf, component.inf].max, [sup, component.sup].min]
+    }.reduce(:union) || Interval[]
   end
 
   # @return [Interval::Multiple]

--- a/spec/interval_simple_spec.rb
+++ b/spec/interval_simple_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'borel/interval'
+
+describe Interval::Simple do
+  context "#intersect" do
+    specify "[1,2]; [[1], [2]] -> [[1], [2]]" do
+      x = Interval[[1, 2]]
+      y = Interval[[1], [2]]
+      expect(x.intersect y).to eq y
+    end
+  end
+
+end


### PR DESCRIPTION
This fixes the bug with interval intersection:

``` ruby
x = Interval[[1, 2]]
y = Interval[[1], [2]]
x.intersect y
# => Interval[1, 2]
```

Now it gives the correct result:

``` ruby
x = Interval[[1, 2]]
y = Interval[[1], [2]]
x.intersect y
# => Interval[[1], [2]]
```
